### PR TITLE
docs: add role-based guidance and navigation links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,149 @@
-# Info
+# AOSSIE Information & Guidance Repository
 
-This repo contains general guidelines for AOSSIE's contributors, mentors and admins.
+This repository contains **official guidance, policies, and rules** for
+**AOSSIE contributors, mentors, admins, and ambassadors**.
+
+All members are expected to read the relevant sections **before participating**
+in AOSSIE projects or programs such as **Google Summer of Code (GSoC)**.
+
+---
+
+## 📌 Who Should Use This Repository?
+
+- 🧑‍💻 Contributors (including GSoC applicants)
+- 👨‍🏫 Mentors
+- 🛡️ Organization Admins
+- 🌍 Ambassadors & Community Representatives
+
+---
+
+## 👩‍💻 Guidance for Contributors
+
+This section applies to **all contributors**, including **newcomers** and
+**GSoC aspirants**.
+
+### Required Reading (Before Contributing)
+
+- **Communication rules and community behavior**  
+  👉 [Communication Guidelines and Rules](https://github.com/AOSSIE-Org/Info/blob/main/CommunicationGuidelinesAndRules.md)
+
+- **Social media usage and representation guidelines**  
+  👉 [Social Media Guidelines](https://github.com/AOSSIE-Org/Info/blob/main/SocialMediaGuidelines.md)
+
+- **Copyright and licensing information**  
+  👉 [Copyright Information](https://github.com/AOSSIE-Org/Info/blob/main/COPYRIGHT.md)
+
+### Contribution Expectations
+
+- Follow respectful and inclusive communication
+- Use GitHub Issues and Pull Requests properly
+- Avoid spam, low-effort, or automated contributions
+- Follow repository-specific contribution instructions
+
+### For GSoC Contributors
+
+- **Mandatory reading before applying**  
+  👉 [Google Summer of Code Guidelines](https://github.com/AOSSIE-Org/Info/blob/main/GoogleSummerOfCode.md)
+
+- Make meaningful contributions **before** proposal submission
+- Interact with mentors publicly via GitHub or Discord
+- Do not submit plagiarized or generic proposals
+
+---
+
+## 👨‍🏫 Guidance for Mentors
+
+This section applies to **project mentors and co-mentors**.
+
+### Mentor Responsibilities
+
+- Guide contributors with constructive and timely feedback
+- Review pull requests consistently
+- Maintain clear and updated project documentation
+- Foster an inclusive and respectful environment
+
+### GSoC Mentors
+
+- Follow all policies defined in  
+  👉 [Google Summer of Code Guidelines](https://github.com/AOSSIE-Org/Info/blob/main/GoogleSummerOfCode.md)
+
+- Avoid conflicts of interest
+- Provide regular evaluations and progress reviews
+- Ensure contributors comply with AOSSIE rules
+
+### Communication
+
+- Use official AOSSIE communication channels
+- Avoid private decision-making that bypasses public discussion
+- Maintain transparency in evaluations and approvals
+
+---
+
+## 🛡️ Guidance for Admins
+
+This section applies to **AOSSIE organization administrators**.
+
+### Administrative Responsibilities
+
+- Maintain and update organization-wide policies
+- Oversee mentor onboarding and project approvals
+- Ensure legal and license compliance
+- Handle moderation, disputes, and escalations
+
+### Program Oversight (GSoC & Others)
+
+- Coordinate with program administrators
+- Review project ideas and mentor eligibility
+- Ensure fair and transparent selection processes
+- Maintain accurate documentation and timelines
+
+---
+
+## 🌍 Guidance for Ambassadors
+
+Ambassadors represent AOSSIE in public forums and platforms.
+
+### Required Reading
+
+- **Ambassador roles and responsibilities**  
+  👉 [Ambassadors Program Guidelines](https://github.com/AOSSIE-Org/Info/blob/main/Ambassadors.md)
+
+- **Social media policies**  
+  👉 [Social Media Guidelines](https://github.com/AOSSIE-Org/Info/blob/main/SocialMediaGuidelines.md)
+
+### Expectations
+
+- Represent AOSSIE professionally
+- Coordinate announcements with admins
+- Follow branding and communication guidelines
+
+---
+
+## 📂 Document Index
+
+| Document | Description |
+|--------|-------------|
+| [Communication Guidelines and Rules](https://github.com/AOSSIE-Org/Info/blob/main/CommunicationGuidelinesAndRules.md) | Community rules and communication standards |
+| [Google Summer of Code Guidelines](https://github.com/AOSSIE-Org/Info/blob/main/GoogleSummerOfCode.md) | GSoC-specific policies and expectations |
+| [Social Media Guidelines](https://github.com/AOSSIE-Org/Info/blob/main/SocialMediaGuidelines.md) | Rules for social media usage |
+| [Ambassadors Program](https://github.com/AOSSIE-Org/Info/blob/main/Ambassadors.md) | Ambassador roles and responsibilities |
+| [Copyright Information](https://github.com/AOSSIE-Org/Info/blob/main/COPYRIGHT.md) | Copyright and ownership details |
+
+---
+
+## ⚠️ Important Notes
+
+- Ignorance of rules is not an excuse
+- Policies apply to all members equally
+- Violations may result in moderation actions
+- Documents may be updated over time
+
+---
+
+## 🤝 Final Note
+
+AOSSIE is built on **transparency, collaboration, and responsibility**.
+All members are expected to contribute in good faith and follow the
+guidelines outlined in this repository.
+
+Happy contributing 🚀


### PR DESCRIPTION
### Summary
This PR updates the repository `README.md` to act as a clear entry point for
AOSSIE contributors, mentors, admins, and ambassadors. It introduces
role-based guidance and provides structured navigation to existing policy
and guideline documents using descriptive text links.

### Motivation
This repository serves as the first place contributors visit before engaging
with AOSSIE projects or programs such as Google Summer of Code (GSoC).
Previously, the README did not clearly guide users based on their roles.
This change improves onboarding clarity and reduces confusion for newcomers,
GSoC applicants, mentors, and admins.

### Changes
- Added separate guidance sections for:
  - Contributors
  - Mentors
  - Admins
  - Ambassadors
- Linked existing documentation (communication rules, GSoC guidelines,
  social media policies, copyright, and ambassador guidelines) using
  descriptive text links
- Improved overall structure and readability of the README

### Scope
- Documentation-only changes
- No functional or behavioral changes to the codebase

### Checklist
- [x] Documentation-only update
- [x] No breaking changes
- [x] Links verified
- [x] Aligned with existing AOSSIE guidelines


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured and expanded project documentation with clearer organization and segmented sections for different user roles (Contributors, Mentors, Admins, Ambassadors).
  * Added a comprehensive Document Index with descriptive links and improved readability guidance for all users.
  * Enhanced onboarding experience with formalized expectations, responsibilities, and communication guidelines.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->